### PR TITLE
Fix "openWhatsApp is not defined" error on vacancies page

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,20 +3,22 @@ const mobileMenuBtn = document.getElementById('mobile-menu-btn');
 const mobileMenu = document.getElementById('mobile-menu');
 const mobileMenuClose = document.getElementById('mobile-menu-close');
 
-mobileMenuBtn.addEventListener('click', () => {
-    mobileMenu.classList.add('open');
-});
+if (mobileMenuBtn && mobileMenu && mobileMenuClose) {
+    mobileMenuBtn.addEventListener('click', () => {
+        mobileMenu.classList.add('open');
+    });
 
-mobileMenuClose.addEventListener('click', () => {
-    mobileMenu.classList.remove('open');
-});
-
-// Close mobile menu when clicking outside
-document.addEventListener('click', (e) => {
-    if (!mobileMenu.contains(e.target) && !mobileMenuBtn.contains(e.target)) {
+    mobileMenuClose.addEventListener('click', () => {
         mobileMenu.classList.remove('open');
-    }
-});
+    });
+
+    // Close mobile menu when clicking outside
+    document.addEventListener('click', (e) => {
+        if (!mobileMenu.contains(e.target) && !mobileMenuBtn.contains(e.target)) {
+            mobileMenu.classList.remove('open');
+        }
+    });
+}
 
 // Mobile accordion functionality
 document.querySelectorAll('.accordion-trigger').forEach(trigger => {
@@ -91,21 +93,24 @@ const whatsappUrl = `https://wa.me/${phoneNumber}?text=${message}`;
 window.open(whatsappUrl, '_blank');
 }
 // Contact form functionality
-document.getElementById('contact-form').addEventListener('submit', (e) => {
-    e.preventDefault();
-    
-    const formData = new FormData(e.target);
-    const name = formData.get('name');
-    const email = formData.get('email');
-    const message = formData.get('message');
-    
-    // Simple validation
-    if (!name || !email || !message) {
-        alert('Пожалуйста, заполните все обязательные поля');
-        return;
-    }
-    
-    // Simulate form submission
-    alert('Спасибо за вашу заявку! Мы свяжемся с вами в ближайшее время.');
-    e.target.reset();
-});
+const contactForm = document.getElementById('contact-form');
+if (contactForm) {
+    contactForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(e.target);
+        const name = formData.get('name');
+        const email = formData.get('email');
+        const message = formData.get('message');
+
+        // Simple validation
+        if (!name || !email || !message) {
+            alert('Пожалуйста, заполните все обязательные поля');
+            return;
+        }
+
+        // Simulate form submission
+        alert('Спасибо за вашу заявку! Мы свяжемся с вами в ближайшее время.');
+        e.target.reset();
+    });
+}


### PR DESCRIPTION
The `main.js` script is loaded on all pages but contained code that expected certain HTML elements (like `#mobile-menu-btn` and `#contact-form`) to be present.

On pages where these elements were missing (such as `vacancies.html`), the script would throw a `TypeError` and crash before all functions, including `openWhatsApp`, were properly defined.

This change wraps the element-specific code in conditional checks to ensure the script runs without errors on all pages, making it more resilient.